### PR TITLE
Add support for multiple interfaces on objects using IHaveCustomMappings

### DIFF
--- a/Heroic.AutoMapper/HeroicAutoMapperConfigurator.cs
+++ b/Heroic.AutoMapper/HeroicAutoMapperConfigurator.cs
@@ -59,14 +59,14 @@ namespace Heroic.AutoMapper
 
         private static void LoadCustomMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
 		{
-			var maps = (from t in types
-						from i in t.GetInterfaces()
-						where typeof(IHaveCustomMappings).IsAssignableFrom(t) &&
-							  !t.IsAbstract &&
-							  !t.IsInterface
-						select (IHaveCustomMappings)Activator.CreateInstance(t)).ToArray();
+		    var maps = types
+		        .Where(t => !t.IsAbstract && !t.IsInterface)
+		        .Where(t => t.GetInterfaces()
+		            .Any(i => typeof(IHaveCustomMappings).IsAssignableFrom(t)))
+		        .Select(t => (IHaveCustomMappings)Activator.CreateInstance(t))
+		        .ToArray();
 
-			foreach (var map in maps)
+            foreach (var map in maps)
 			{
 				map.CreateMappings(cfg);
 			}
@@ -74,18 +74,18 @@ namespace Heroic.AutoMapper
 
 		private static void LoadIMapFromMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
 		{
-			var maps = (from t in types
-						from i in t.GetInterfaces()
-						where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>) &&
-							  !t.IsAbstract &&
-							  !t.IsInterface
-						select new
-						{
-							Source = i.GetGenericArguments()[0],
-							Destination = t
-						}).ToArray();
+            var maps = (from t in types
+                        from i in t.GetInterfaces()
+                        where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>) &&
+                              !t.IsAbstract &&
+                              !t.IsInterface
+                        select new
+                        {
+                            Source = i.GetGenericArguments()[0],
+                            Destination = t
+                        }).ToArray();
 
-			foreach (var map in maps)
+            foreach (var map in maps)
 			{
 				cfg.CreateMap(map.Source, map.Destination);
 			}

--- a/Heroic.AutoMapper/HeroicAutoMapperConfigurator.cs
+++ b/Heroic.AutoMapper/HeroicAutoMapperConfigurator.cs
@@ -6,51 +6,54 @@ using AutoMapper;
 
 namespace Heroic.AutoMapper
 {
-	public static class HeroicAutoMapperConfigurator
-	{
-		public static void LoadMapsFromAssemblyContainingTypeAndReferencedAssemblies<TType>(Func<AssemblyName, bool> assemblyFilter = null)
-		{
-			var target = typeof (TType).Assembly;
+    public static class HeroicAutoMapperConfigurator
+    {
+        public static void LoadMapsFromAssemblyContainingTypeAndReferencedAssemblies<TType>(IMapperConfigurationExpression cfg = null, Func<AssemblyName, bool> assemblyFilter = null)
+        {
+            var target = typeof(TType).Assembly;
 
-			Func<AssemblyName, bool> loadAllFilter = (x => true);
+            Func<AssemblyName, bool> loadAllFilter = (x => true);
 
-			var assembliesToLoad = target.GetReferencedAssemblies()
-				.Where(assemblyFilter ?? loadAllFilter)
-				.Select(a => Assembly.Load(a))
-				.ToList();
+            var assembliesToLoad = target.GetReferencedAssemblies()
+                .Where(assemblyFilter ?? loadAllFilter)
+                .Select(a => Assembly.Load(a))
+                .ToList();
 
-			assembliesToLoad.Add(target);
+            assembliesToLoad.Add(target);
 
-			LoadMapsFromAssemblies(assembliesToLoad.ToArray());
-		}
-
-		public static void LoadMapsFromCallerAndReferencedAssemblies(Func<AssemblyName, bool> assemblyFilter = null)
-		{
-			var target = Assembly.GetCallingAssembly();
-
-			Func<AssemblyName, bool> loadAllFilter = (x => true);
-
-			var assembliesToLoad = target.GetReferencedAssemblies()
-				.Where(assemblyFilter ?? loadAllFilter)
-				.Select(a => Assembly.Load(a))
-				.ToList();
-
-			assembliesToLoad.Add(target);
-
-			LoadMapsFromAssemblies(assembliesToLoad.ToArray());
-		}
-
-		public static void LoadMapsFromAssemblies(params Assembly[] assemblies)
-		{
-			var types = assemblies.SelectMany(a => a.GetExportedTypes()).ToArray();
-
-            #pragma warning disable 618
-		    Mapper.Initialize(cfg => Load(cfg, types));
-            #pragma warning restore 618
+            LoadMapsFromAssemblies(cfg, assembliesToLoad.ToArray());
         }
 
-	    private static void Load(IMapperConfigurationExpression cfg, Type[] types)
-	    {
+        public static void LoadMapsFromCallerAndReferencedAssemblies(IMapperConfigurationExpression cfg = null, Func<AssemblyName, bool> assemblyFilter = null)
+        {
+            var target = Assembly.GetCallingAssembly();
+
+            Func<AssemblyName, bool> loadAllFilter = (x => true);
+
+            var assembliesToLoad = target.GetReferencedAssemblies()
+                .Where(assemblyFilter ?? loadAllFilter)
+                .Select(a => Assembly.Load(a))
+                .ToList();
+
+            assembliesToLoad.Add(target);
+
+            LoadMapsFromAssemblies(cfg, assembliesToLoad.ToArray());
+        }
+
+        public static void LoadMapsFromAssemblies(IMapperConfigurationExpression cfg, params Assembly[] assemblies)
+        {
+            var types = assemblies.SelectMany(a => a.GetExportedTypes()).ToArray();
+
+            if (cfg != null)
+                Load(cfg, types);
+            else
+#pragma warning disable 618
+                Mapper.Initialize(c => Load(c, types));
+#pragma warning restore 618
+        }
+
+        private static void Load(IMapperConfigurationExpression cfg, Type[] types)
+        {
             LoadIMapFromMappings(cfg, types);
             LoadIMapToMappings(cfg, types);
 
@@ -58,22 +61,22 @@ namespace Heroic.AutoMapper
         }
 
         private static void LoadCustomMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
-		{
-		    var maps = types
-		        .Where(t => !t.IsAbstract && !t.IsInterface)
-		        .Where(t => t.GetInterfaces()
-		            .Any(i => typeof(IHaveCustomMappings).IsAssignableFrom(t)))
-		        .Select(t => (IHaveCustomMappings)Activator.CreateInstance(t))
-		        .ToArray();
+        {
+            var maps = types
+                .Where(t => !t.IsAbstract && !t.IsInterface)
+                .Where(t => t.GetInterfaces()
+                    .Any(i => typeof(IHaveCustomMappings).IsAssignableFrom(t)))
+                .Select(t => (IHaveCustomMappings)Activator.CreateInstance(t))
+                .ToArray();
 
             foreach (var map in maps)
-			{
-				map.CreateMappings(cfg);
-			}
-		}
+            {
+                map.CreateMappings(cfg);
+            }
+        }
 
-		private static void LoadIMapFromMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
-		{
+        private static void LoadIMapFromMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
+        {
             var maps = (from t in types
                         from i in t.GetInterfaces()
                         where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>) &&
@@ -86,29 +89,29 @@ namespace Heroic.AutoMapper
                         }).ToArray();
 
             foreach (var map in maps)
-			{
-				cfg.CreateMap(map.Source, map.Destination);
-			}
-		}
+            {
+                cfg.CreateMap(map.Source, map.Destination);
+            }
+        }
 
-		private static void LoadIMapToMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
-		{
-			var maps = (from t in types
-						from i in t.GetInterfaces()
-						where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapTo<>) &&
-							  !t.IsAbstract &&
-							  !t.IsInterface
-						select new
-						{
-							Destination = i.GetGenericArguments()[0],
-							Source = t
-						}).ToArray();
+        private static void LoadIMapToMappings(IMapperConfigurationExpression cfg, IEnumerable<Type> types)
+        {
+            var maps = (from t in types
+                        from i in t.GetInterfaces()
+                        where i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapTo<>) &&
+                              !t.IsAbstract &&
+                              !t.IsInterface
+                        select new
+                        {
+                            Destination = i.GetGenericArguments()[0],
+                            Source = t
+                        }).ToArray();
 
-			foreach (var map in maps)
-			{
-				cfg.CreateMap(map.Source, map.Destination);
-			}
-		}
-	}
+            foreach (var map in maps)
+            {
+                cfg.CreateMap(map.Source, map.Destination);
+            }
+        }
+    }
 
 }


### PR DESCRIPTION
If an object implements IHaveCustomMappings and also implements another interface, the mapping will be duplicated for each additional interface.